### PR TITLE
migrate pypi related code from napari core

### DIFF
--- a/napari_plugin_engine/pypi.py
+++ b/napari_plugin_engine/pypi.py
@@ -1,0 +1,248 @@
+"""
+These convenience functions will be useful for searching pypi for packages
+that match the plugin naming convention, and retrieving related metadata.
+"""
+import json
+import os
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import lru_cache
+from typing import Dict, Generator, List, NamedTuple, Optional, Tuple
+from urllib import error, parse, request
+
+PYPI_SIMPLE_API_URL = 'https://pypi.org/simple/'
+
+setup_py_entrypoint = re.compile(
+    r"entry_points\s?=\s?([^}]*napari.plugin[^}]*)}"
+)
+setup_py_pypi_name = re.compile(
+    r"setup\s?\(.*name\s?=\s?['\"]([^'\"]+)['\"]", re.DOTALL
+)
+
+
+class ProjectInfo(NamedTuple):
+    """Info associated with a PyPI Project."""
+
+    name: str
+    version: str
+    url: str
+    summary: str
+    author: str
+    license: str
+
+
+@lru_cache(maxsize=128)
+def get_packages_by_prefix(prefix: str) -> Dict[str, str]:
+    """Search for packages starting with ``prefix`` on pypi.
+
+    Packages using naming convention: http://bit.ly/pynaming-convention
+    can be autodiscovered on pypi using the SIMPLE API:
+    https://www.python.org/dev/peps/pep-0503/
+
+    Returns
+    -------
+    dict
+        {name: url} for all packages at pypi that start with ``prefix``
+    """
+
+    with request.urlopen(PYPI_SIMPLE_API_URL) as response:
+        html = response.read().decode()
+
+    return {
+        name: PYPI_SIMPLE_API_URL + url
+        for url, name in re.findall(
+            f'<a href="/simple/(.+)">({prefix}.*)</a>', html
+        )
+    }
+
+
+@lru_cache(maxsize=128)
+def get_packages_by_classifier(classifier: str) -> List[str]:
+    """Search for packages declaring ``classifier`` on PyPI
+
+    Yields
+    -------
+    name : str
+        name of all packages at pypi that declare ``classifier``
+    """
+
+    url = f"https://pypi.org/search/?c={parse.quote_plus(classifier)}"
+    with request.urlopen(url) as response:
+        html = response.read().decode()
+
+    return re.findall('class="package-snippet__name">(.+)</span>', html)
+
+
+@lru_cache(maxsize=128)
+def get_package_versions(name: str) -> List[str]:
+    """Get available versions of a package on pypi
+
+    Parameters
+    ----------
+    name : str
+        name of the package
+
+    Returns
+    -------
+    tuple
+        versions available on pypi
+    """
+    with request.urlopen(PYPI_SIMPLE_API_URL + name) as response:
+        html = response.read()
+
+    return re.findall(f'>{name}-(.+).tar', html.decode())
+
+
+@lru_cache(maxsize=1)
+def get_napari_plugin_repos_from_github() -> List[dict]:
+    """Return GitHub API hits for repos with "napari plugin" in the README."""
+    with request.urlopen(
+        'https://api.github.com/search/repositories?q="napari+plugin"+in:readme'
+    ) as response:
+        data = json.loads(response.read().decode())
+        return list(data.get("items"))
+
+
+@lru_cache(maxsize=128)
+def ensure_published_at_pypi(
+    name: str, min_dev_status=3
+) -> Optional[ProjectInfo]:
+    """Return name if ``name`` is a package in PyPI with dev_status > min."""
+    try:
+        with request.urlopen(f'https://pypi.org/pypi/{name}/json') as resp:
+            info = json.loads(resp.read().decode()).get("info")
+    except error.HTTPError:
+        return None
+    classifiers = info.get("classifiers")
+    for i in range(1, min_dev_status):
+        if any(f'Development Status :: {1}' in x for x in classifiers):
+            return None
+
+    return ProjectInfo(
+        name=normalized_name(info["name"]),
+        version=info["version"],
+        url=info["home_page"],
+        summary=info["summary"],
+        author=info["author"],
+        license=info["license"] or "UNKNOWN",
+    )
+
+
+@lru_cache(maxsize=128)
+def ensure_repo_is_napari_plugin(
+    info: Tuple[str, str]
+) -> Optional[ProjectInfo]:
+    """Return ProjectInfo of published napari plugin or None.
+
+    This function looks for a setup.py or setup.cfg file in the default branch
+    of the repo, then looks for a "napari.plugins" in the entry_points section.
+    As such, it will only currently find projects that use setuptools.
+
+    Parameters
+    ----------
+    info : tuple
+        2-tuple containing full repo name on github (e.g. "napari/napari"), and
+        branch to query (e.g. "master")
+
+    Returns
+    -------
+    info : ProjectInfo, optional
+        named tuple with project info or None
+
+    """
+    # otherwise... we have to look for the entry_point
+    base = 'https://raw.githubusercontent.com/{}/{}/'.format(*info)
+
+    # first check setup.py
+    try:
+        with request.urlopen(base + "setup.py") as resp:
+            text = resp.read().decode()
+        match = setup_py_entrypoint.search(text)
+        if match:
+            if any(
+                'napari.plugin' in line.split("#")[0]
+                for line in match.groups()[0].splitlines()
+            ):
+                name = setup_py_pypi_name.search(text)
+                if name:
+                    return ensure_published_at_pypi(name.groups()[0])
+    except error.HTTPError:  # usually 404
+        pass
+
+    # then check setup.cfg
+    try:
+        import configparser
+
+        with request.urlopen(base + "setup.cfg") as resp:
+            text = resp.read().decode()
+        parser = configparser.ConfigParser()
+        parser.read_string(text)
+        if parser.has_option('options.entry_points', 'napari.plugin'):
+            return ensure_published_at_pypi(parser.get("metadata", "name"))
+    except error.HTTPError:
+        pass
+    return None
+
+
+def iter_napari_plugin_info(
+    skip={'napari-plugin-engine'},
+) -> Generator[ProjectInfo, None, None]:
+    """Return a generator that yields ProjectInfo of available napari plugins.
+
+    By default, requires that packages are at least "Alpha" stage of
+    development.  to allow lower, change the ``min_dev_status`` argument to
+    ``ensure_published_at_pypi``.
+    """
+    already_yielded = set()
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [
+            executor.submit(ensure_published_at_pypi, name)
+            for name in get_packages_by_classifier("Framework :: napari")
+            if name not in skip
+        ]
+
+        futures.extend(
+            [
+                executor.submit(
+                    ensure_repo_is_napari_plugin,
+                    (repo_info['full_name'], repo_info['default_branch']),
+                )
+                for repo_info in get_napari_plugin_repos_from_github()
+                if repo_info['name'] not in skip  # repo may not have pkg name
+            ]
+        )
+        for future in as_completed(futures):
+            info = future.result()
+            if info and info not in already_yielded:
+                already_yielded.add(info)
+                yield info
+
+
+@lru_cache(maxsize=1)
+def list_outdated() -> Dict[str, Tuple[str, ...]]:
+    # slow!
+    import subprocess
+
+    from ..utils._appdirs import user_site_packages
+
+    env = os.environ.copy()
+    combined = os.pathsep.join(
+        [user_site_packages(), env.get("PYTHONPATH", "")]
+    )
+    env['PYTHONPATH'] = combined
+    result = subprocess.check_output(
+        [sys.executable, '-m', 'pip', 'list', '--outdated'], env=env
+    )
+    lines = result.decode().splitlines()
+    if len(lines) <= 2:
+        return {}
+    out = dict()
+    for line in lines[2:]:
+        name, *rest = line.split()
+        out[name] = tuple(rest[:2])
+    return out
+
+
+def normalized_name(name) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()

--- a/testing/test_pypi.py
+++ b/testing/test_pypi.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from napari_plugin_engine import pypi
+
+
+class FakeResponse:
+    def __init__(self, *, data: bytes):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return
+
+
+txtA = (
+    b'<!DOCTYPE html>\n<html>\n  <head>\n  <title>Simple index</title>'
+    b'\n </head>\n  <body>\n  <a href="/simple/package1/">package1</a>'
+    b'\n  <a href="/simple/package2/">packge2</a>\n   </body>\n</html>'
+)
+
+txtB = (
+    b'<!DOCTYPE html>\n<html>\n  <head>\n    <title>Links for package'
+    b'</title>\n  </head>\n  <body>\n    <h1>Links for package</h1>\n'
+    b'<a href="http://pythonhosted.org/package-0.1.0.tar.gz#sha256=7">'
+    b'package-0.1.0.tar.gz</a><br/>\n </body>\n</html>'
+)
+
+
+@mock.patch(
+    'napari_plugin_engine.pypi.request.urlopen', return_value=FakeResponse(data=txtA)
+)
+def test_get_packages_by_prefix(mock_get):
+    urls = pypi.get_packages_by_prefix('package')
+    assert 'package1' in urls
+    assert urls['package1'] == 'https://pypi.org/simple/package1/'
+
+
+@mock.patch(
+    'napari_plugin_engine.pypi.request.urlopen', return_value=FakeResponse(data=txtB)
+)
+def test_get_package_versions(mock_get):
+    versions = pypi.get_package_versions('package')
+    assert '0.1.0' in versions

--- a/testing/test_pypi.py
+++ b/testing/test_pypi.py
@@ -35,7 +35,8 @@ txtB = (
 
 
 @mock.patch(
-    'napari_plugin_engine.pypi.request.urlopen', return_value=FakeResponse(data=txtA)
+    'napari_plugin_engine.pypi.request.urlopen',
+    return_value=FakeResponse(data=txtA),
 )
 def test_get_packages_by_prefix(mock_get):
     urls = pypi.get_packages_by_prefix('package')
@@ -44,7 +45,8 @@ def test_get_packages_by_prefix(mock_get):
 
 
 @mock.patch(
-    'napari_plugin_engine.pypi.request.urlopen', return_value=FakeResponse(data=txtB)
+    'napari_plugin_engine.pypi.request.urlopen',
+    return_value=FakeResponse(data=txtB),
 )
 def test_get_package_versions(mock_get):
     versions = pypi.get_package_versions('package')


### PR DESCRIPTION
migrate pypi related code to plugin engine to allow access from plugin dependencies without importing napari

closes #13 