### PR TITLE
Add currently blocked plugins to the string repr of plugin_manager

### DIFF
--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -253,8 +253,7 @@ class PluginManager:
 
     @contextmanager
     def discovery_blocked(self) -> Generator:
-        """A context manager that temporarily blocks discovery of new plugins.
-        """
+        """A context manager that temporarily blocks discovery of new plugins."""
         current = self.hook._needs_discovery
         self.hook._needs_discovery = False
         try:
@@ -263,7 +262,7 @@ class PluginManager:
             self.hook._needs_discovery = current
 
     def _load_and_register(
-        self, mod_name: str, plugin_name: Optional[str] = None,
+        self, mod_name: str, plugin_name: Optional[str] = None
     ) -> Optional[str]:
         """A helper function to import and register a module as ``plugin_name``.
 
@@ -508,23 +507,17 @@ class PluginManager:
             tag = HookSpecification.format_tag(self.project_name)
             spec_opts = getattr(method, tag, None)
             if spec_opts is not None:
-                hook_caller = getattr(self.hook, name, None,)
+                hook_caller = getattr(self.hook, name, None)
                 if hook_caller is None:
                     hook_caller = HookCaller(
-                        name, self._hookexec, namespace, spec_opts,
+                        name, self._hookexec, namespace, spec_opts
                     )
-                    setattr(
-                        self.hook, name, hook_caller,
-                    )
+                    setattr(self.hook, name, hook_caller)
                 else:
                     # plugins registered this hook without knowing the spec
-                    hook_caller.set_specification(
-                        namespace, spec_opts,
-                    )
+                    hook_caller.set_specification(namespace, spec_opts)
                     for hookfunction in hook_caller.get_hookimpls():
-                        self._verify_hook(
-                            hook_caller, hookfunction,
-                        )
+                        self._verify_hook(hook_caller, hookfunction)
                 names.append(name)
 
         if not names:
@@ -720,13 +713,9 @@ class PluginManager:
             hooktrace.root.indent += 1
             hooktrace(hook_name, kwargs)
 
-        def after(
-            outcome, hook_name, methods, kwargs,
-        ):
+        def after(outcome, hook_name, methods, kwargs):
             if outcome.excinfo is None:
-                hooktrace(
-                    "finish", hook_name, "-->", outcome.result,
-                )
+                hooktrace("finish", hook_name, "-->", outcome.result)
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)
@@ -871,7 +860,7 @@ class _HookRelay:
 
     def __getattribute__(self, name) -> HookCaller:
         """Trigger manager plugin discovery when accessing hook first time."""
-        if name not in ("_needs_discovery", "_manager",):
+        if name not in ("_needs_discovery", "_manager"):
             if self._needs_discovery:
                 self._manager.discover()
         return object.__getattribute__(self, name)
@@ -900,7 +889,7 @@ class _HookRelay:
 
 
 def get_canonical_name(namespace: Any) -> str:
-    """ Return canonical name for a plugin object.
+    """Return canonical name for a plugin object.
 
     Note that a plugin may be registered under a different name which was
     specified by the caller of :meth:`PluginManager.register(plugin, name)

--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -823,6 +823,9 @@ class PluginManager:
             # nhooks = len(self._plugin2hookcallers[plugin])
             # text += f'{name:29}  {nhooks:3} hooks\n'
 
+        if self._blocked:
+            text += '\nBlocked Plugins:\n----------------\n'
+            text += "\n".join(self._blocked)
         return text
 
     def plugin_info(self, plugin) -> str:

--- a/testing/test_discovery.py
+++ b/testing/test_discovery.py
@@ -239,8 +239,7 @@ def test_plugin_discovery_by_prefix(
     app_good_plugin,
     app_invalid_plugin,
 ):
-    """Make sure b
-    """
+    """Make sure discovery by package prefix works"""
 
     @add_specification
     def test_specification(arg1, arg2):


### PR DESCRIPTION
just adds currently blocked plugins to the string repr (which is what you get in `--plugin-info`