### PR TITLE
Implement_add_hookspec_dict in add_hookspecs

### DIFF
--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -521,10 +521,10 @@ class PluginManager:
 
         Functions are recognized if they have been decorated accordingly.
         """
-        
+
         if isinstance(namespace, dict):
             return self._add_hookspec_dict(namespace)
-        
+
         names = []
         for name in dir(namespace):
             method = getattr(namespace, name)

--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -521,6 +521,10 @@ class PluginManager:
 
         Functions are recognized if they have been decorated accordingly.
         """
+        
+        if isinstance(namespace, dict):
+            return self._add_hookspec_dict(namespace)
+        
         names = []
         for name in dir(namespace):
             method = getattr(namespace, name)


### PR DESCRIPTION
Currently, register calls _register_dict if namespace is a dict. It seems like this functionality was also intended for add_hookspecs, but _add_hookspec_dict is never called anywhere in either napari or napari_plugin_engine. The four functions' git blame patterns lead me to believe this was an accident.