### PR TITLE
Protect against unraised instances of PluginError

### DIFF
--- a/napari_plugin_engine/exceptions.py
+++ b/napari_plugin_engine/exceptions.py
@@ -56,6 +56,12 @@ class PluginError(Exception):
         # store all PluginError instances.  can be retrieved with get()
         PluginError._record.append(self)
 
+    def _check_traceback(self):
+        if self.__traceback__ is None:
+            raise RuntimeError(
+                f"{type(self)}.__traceback__ is None, did you forget to `raise` it ?"
+            )
+
     @classmethod
     def get(
         cls,
@@ -106,10 +112,12 @@ class PluginError(Exception):
                     )
                 if not isinstance(error.__cause__, error_type):
                     continue
+            error._check_traceback()
             errors.append(error)
         return errors
 
     def format(self, package_info: bool = True):
+        self._check_traceback()
         msg = f'PluginError: {self}'
         if self.__cause__:
             msg = msg.replace(str(self.__cause__), '').strip(": ") + "\n"
@@ -164,6 +172,7 @@ class PluginError(Exception):
         level : int, optional
             The logging level to use, by default logging.ERROR
         """
+        self._check_traceback()
         if not isinstance(logger, logging.Logger):
             logger = logging.getLogger(logger)
 
@@ -171,6 +180,7 @@ class PluginError(Exception):
 
     def info(self) -> ExcInfoTuple:
         """Return info as would be returned from sys.exc_info()."""
+        self._check_traceback()
         return (self.__class__, self, self.__traceback__)
 
 


### PR DESCRIPTION
See napari/napari#3156

It looks like PluginError class keep reference to all instances of
PluginError created, but creating a PluginError does not mean it has
been raised.

If it is not raised, it's `__traceback__` attribute is set tot None,
which is problematic for many traceback formatting logic.