### PR TITLE
don't block plugins that fail to import

### DIFF
--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -267,6 +267,9 @@ class PluginManager:
                     self._id_counts[old_name] += 1
             except PluginError as e:
                 errs.append(e)
+                # commenting out for now, because napari stores this blockage
+                # too permanently, and it's hard to differentiate between
+                # plugins intentionally blocked by the user.
                 # self.set_blocked(name)
                 if ignore_errors:
                     continue

--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -253,8 +253,7 @@ class PluginManager:
 
     @contextmanager
     def discovery_blocked(self) -> Generator:
-        """A context manager that temporarily blocks discovery of new plugins.
-        """
+        """A context manager that temporarily blocks discovery of new plugins."""
         current = self.hook._needs_discovery
         self.hook._needs_discovery = False
         try:
@@ -263,7 +262,7 @@ class PluginManager:
             self.hook._needs_discovery = current
 
     def _load_and_register(
-        self, mod_name: str, plugin_name: Optional[str] = None,
+        self, mod_name: str, plugin_name: Optional[str] = None
     ) -> Optional[str]:
         """A helper function to import and register a module as ``plugin_name``.
 
@@ -508,23 +507,17 @@ class PluginManager:
             tag = HookSpecification.format_tag(self.project_name)
             spec_opts = getattr(method, tag, None)
             if spec_opts is not None:
-                hook_caller = getattr(self.hook, name, None,)
+                hook_caller = getattr(self.hook, name, None)
                 if hook_caller is None:
                     hook_caller = HookCaller(
-                        name, self._hookexec, namespace, spec_opts,
+                        name, self._hookexec, namespace, spec_opts
                     )
-                    setattr(
-                        self.hook, name, hook_caller,
-                    )
+                    setattr(self.hook, name, hook_caller)
                 else:
                     # plugins registered this hook without knowing the spec
-                    hook_caller.set_specification(
-                        namespace, spec_opts,
-                    )
+                    hook_caller.set_specification(namespace, spec_opts)
                     for hookfunction in hook_caller.get_hookimpls():
-                        self._verify_hook(
-                            hook_caller, hookfunction,
-                        )
+                        self._verify_hook(hook_caller, hookfunction)
                 names.append(name)
 
         if not names:
@@ -720,13 +713,9 @@ class PluginManager:
             hooktrace.root.indent += 1
             hooktrace(hook_name, kwargs)
 
-        def after(
-            outcome, hook_name, methods, kwargs,
-        ):
+        def after(outcome, hook_name, methods, kwargs):
             if outcome.excinfo is None:
-                hooktrace(
-                    "finish", hook_name, "-->", outcome.result,
-                )
+                hooktrace("finish", hook_name, "-->", outcome.result)
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)
@@ -871,7 +860,7 @@ class _HookRelay:
 
     def __getattribute__(self, name) -> HookCaller:
         """Trigger manager plugin discovery when accessing hook first time."""
-        if name not in ("_needs_discovery", "_manager",):
+        if name not in ("_needs_discovery", "_manager"):
             if self._needs_discovery:
                 self._manager.discover()
         return object.__getattribute__(self, name)
@@ -900,7 +889,7 @@ class _HookRelay:
 
 
 def get_canonical_name(namespace: Any) -> str:
-    """ Return canonical name for a plugin object.
+    """Return canonical name for a plugin object.
 
     Note that a plugin may be registered under a different name which was
     specified by the caller of :meth:`PluginManager.register(plugin, name)

--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -1082,7 +1082,7 @@ def iter_available_plugins(
                 continue
             if prefix and not os.getenv("DISABLE_PREFIX_PLUGINS"):
                 name = dist.metadata.get("name")
-                if name == prefix or (not name.startswith(prefix)):
+                if not name or name == prefix or (not name.startswith(prefix)):
                     continue
                 top_modules = dist.read_text('top_level.txt') or ""
                 for mod in filter(None, top_modules.split('\n')):

--- a/napari_plugin_engine/manager.py
+++ b/napari_plugin_engine/manager.py
@@ -267,7 +267,7 @@ class PluginManager:
                     self._id_counts[old_name] += 1
             except PluginError as e:
                 errs.append(e)
-                self.set_blocked(name)
+                # self.set_blocked(name)
                 if ignore_errors:
                     continue
                 raise e

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = napari-plugin-engin
+name = napari-plugin-engine
 url = https://github.com/napari/napari-plugin-engine
 license = MIT
 license_file = LICENSE

--- a/testing/test_discovery.py
+++ b/testing/test_discovery.py
@@ -270,7 +270,7 @@ def test_plugin_discovery_by_prefix(
     assert errs
     assert isinstance(errs[0], PluginValidationError)
     # and it should now be blocked
-    assert test_plugin_manager.is_blocked('app_invalid_plugin')
+    # assert test_plugin_manager.is_blocked('app_invalid_plugin')
 
     # if we unblock the plugin and turn off ignore_errors
     # we'll get a registration error at discovery

--- a/testing/test_discovery.py
+++ b/testing/test_discovery.py
@@ -239,8 +239,7 @@ def test_plugin_discovery_by_prefix(
     app_good_plugin,
     app_invalid_plugin,
 ):
-    """Make sure b
-    """
+    """Make sure discovery by package prefix works"""
 
     @add_specification
     def test_specification(arg1, arg2):

--- a/testing/test_discovery.py
+++ b/testing/test_discovery.py
@@ -328,7 +328,7 @@ def test_plugin_discovery_by_entry_point(
     assert errs
     assert isinstance(errs[0], PluginValidationError)
     # and it should now be blocked
-    assert test_plugin_manager.is_blocked('invalid')
+    # assert test_plugin_manager.is_blocked('invalid')
 
     # if we unblock the plugin and turn off ignore_errors
     # we'll get a registration error at discovery


### PR DESCRIPTION
This PR turns off blocking of plugins that fail to import.  This is just a patch, not a great solution, but now that blocked plugins are saved in napari settings, this causes problems with plugin development, because when an error occurs, it stays blocked.

the "cost" here is that a broken plugin may get "tried" a few times in the course of a session (instead of remembering that it shouldn't be tried again).  that's much better though than needing to reset settings in order to get it back