### PR TITLE
Add badge and heading to highlight npe2 as preferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@
 [![codecov](https://codecov.io/gh/napari/napari/branch/master/graph/badge.svg)](https://codecov.io/gh/napari/napari)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-plugin-engine.svg?color=green)](https://python.org)
 [![PyPI](https://img.shields.io/pypi/v/napari-plugin-engine.svg?color=green)](https://pypi.org/project/napari-plugin-engine)
+![Deprecated](https://img.shields.io/badge/status-deprecated-orange)
 
-`napari-plugin-engine` is the first generation napari plugin engine. We
-recommend new plugins should use the second generation [npe2](https://github.com/napari/npe2).
+
+⛔️ DEPRECATED [napari-plugin-engine](https://github.com/napari/napari-plugin-engine) is the first generation napari plugin engine.
+
+✅ We recommend new plugins should use the second generation [npe2](https://github.com/napari/npe2).
+
+---
 
 `napari-plugin-engine` is a fork of [pluggy](https://github.com/pytest-dev/pluggy),
 modified by the [napari](https://github.com/napari/napari) team.


### PR DESCRIPTION
This PR adds:
- a badge to signify that this repo is deprecated.
- adds emojis and test to highlight npe2 should be used
- add a line to offset the top block from the existing README content

As a new contributor, this clarifies which plugin engine is preferred and actively maintained.