### PR TITLE
Update .pre-commit-config.yaml versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.950"
+    rev: "v1.13.0"
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,8 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,3 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,6 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.13.0"
-    hooks:
-      - id: mypy

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ extras = test
 commands = pytest --color=yes -v --cov --cov-report=xml {posargs}
 
 [testenv:napari]
-basepython = python3.8
+basepython = python3.7
 deps = 
     git+https://github.com/napari/napari.git#egg=napari[all,testing]
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ extras = test
 commands = pytest --color=yes -v --cov --cov-report=xml {posargs}
 
 [testenv:napari]
-basepython = python3.7
+basepython = python3.8
 deps = 
     git+https://github.com/napari/napari.git#egg=napari[all,testing]
 commands = 


### PR DESCRIPTION
Try to fix CI errors.

precommit is grumpy with these older versions and the introduction of importlib.metadata in Python 3.8. I removed the flake8 and mypy recommit checks and bumped the failing isort config since at this point the deprecated repo (replaced by npe2) should only be updating README content.