### PR TITLE
Add a more prominent deprecation to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,3 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.950"
-    hooks:
-      - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: rev: 6.0.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: rev: 6.0.0
+    rev: 6.0.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -7,8 +7,17 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-plugin-engine.svg?color=green)](https://python.org)
 [![PyPI](https://img.shields.io/pypi/v/napari-plugin-engine.svg?color=green)](https://pypi.org/project/napari-plugin-engine)
 
+---
+
+**DEPRECATED**:
+
+This project is deprecated. Please use [npe2](https://github.com/napari/npe2) instead.
+
 `napari-plugin-engine` is the first generation napari plugin engine. We
-recommend new plugins should use the second generation [npe2](https://github.com/napari/npe2).
+recommend new plugins use the second generation [npe2](https://github.com/napari/npe2)
+and existing plugins migrate to npe2.
+
+---
 
 `napari-plugin-engine` is a fork of [pluggy](https://github.com/pytest-dev/pluggy),
 modified by the [napari](https://github.com/napari/napari) team.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@
 This project is deprecated. Please use [npe2](https://github.com/napari/npe2) instead.
 
 `napari-plugin-engine` is the first generation napari plugin engine. We
-recommend new plugins use the second generation [npe2](https://github.com/napari/npe2)
-and existing plugins migrate to npe2.
+recommend:
+- new plugins use the second generation [npe2](https://github.com/napari/npe2)
+- existing plugins migrate to npe2 using the [Migration Guide](https://napari.org/stable/plugins/advanced_topics/npe2_migration_guide.html) in our docs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![codecov](https://codecov.io/gh/napari/napari/branch/master/graph/badge.svg)](https://codecov.io/gh/napari/napari)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-plugin-engine.svg?color=green)](https://python.org)
 [![PyPI](https://img.shields.io/pypi/v/napari-plugin-engine.svg?color=green)](https://pypi.org/project/napari-plugin-engine)
+![Deprecated](https://img.shields.io/badge/status-deprecated-orange)
 
 ---
 


### PR DESCRIPTION
This PR adds more prominent deprecation notice and links to migration information to npe2. It updates the recommit file to a current isort version and removes those checks with conflicts. cc/ @DragaDoncila @psobolewskiPhD 